### PR TITLE
Add GitHub and LinkedIn social links to landing page

### DIFF
--- a/src/Landing.js
+++ b/src/Landing.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { InstagramIcon, IG_URL } from './Nav';
+import { InstagramIcon, IG_URL, GithubIcon, GH_URL, LinkedInIcon, LI_URL } from './Nav';
 
 const Landing = () => (
   <main className="landing">
@@ -37,6 +37,15 @@ const Landing = () => (
           <span className="arr">↗</span>
         </a>
       </nav>
+
+      <div className="socials" aria-label="Elsewhere">
+        <a href={GH_URL} target="_blank" rel="noopener noreferrer">
+          <GithubIcon /> <span>GitHub</span>
+        </a>
+        <a href={LI_URL} target="_blank" rel="noopener noreferrer">
+          <LinkedInIcon /> <span>LinkedIn</span>
+        </a>
+      </div>
     </div>
   </main>
 );

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -2,17 +2,41 @@ import React from 'react';
 import { Link, withRouter } from 'react-router-dom';
 
 const IG_URL = 'https://www.instagram.com/awong.photo/';
+const GH_URL = 'https://github.com/andrewwong97';
+const LI_URL = 'https://www.linkedin.com/in/andrewwong97';
+
+const iconBase = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.6,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+  'aria-hidden': true,
+};
 
 const InstagramIcon = ({ size = 13 }) => (
   <svg
-    viewBox="0 0 24 24" width={size} height={size}
-    fill="none" stroke="currentColor" strokeWidth="1.6"
-    strokeLinecap="round" strokeLinejoin="round"
-    aria-hidden="true" style={{ verticalAlign: '-2px', marginLeft: 4 }}
+    {...iconBase} width={size} height={size}
+    style={{ verticalAlign: '-2px', marginLeft: 4 }}
   >
     <rect x="3" y="3" width="18" height="18" rx="5" />
     <circle cx="12" cy="12" r="4" />
     <circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+const GithubIcon = ({ size = 14 }) => (
+  <svg {...iconBase} width={size} height={size}>
+    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+  </svg>
+);
+
+const LinkedInIcon = ({ size = 14 }) => (
+  <svg {...iconBase} width={size} height={size}>
+    <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-4 0v7h-4v-7a6 6 0 0 1 6-6z" />
+    <rect x="2" y="9" width="4" height="12" />
+    <circle cx="4" cy="4" r="2" />
   </svg>
 );
 
@@ -40,5 +64,5 @@ const Nav = ({ location }) => {
   );
 };
 
-export { InstagramIcon, IG_URL };
+export { InstagramIcon, IG_URL, GithubIcon, GH_URL, LinkedInIcon, LI_URL };
 export default withRouter(Nav);

--- a/src/design-system.css
+++ b/src/design-system.css
@@ -357,6 +357,28 @@ footer.page-footer a:hover { border-color: var(--accent); }
   text-align: center;
 }
 
+.landing .socials {
+  margin-top: 28px;
+  display: flex;
+  gap: 22px;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.landing .socials a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+  transition: color .15s, border-color .15s;
+}
+.landing .socials a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
 @media (max-width: 520px) {
   .landing nav.primary a,
   .landing nav.primary .coming { grid-template-columns: 28px 1fr 44px; gap: 14px; }


### PR DESCRIPTION
## Summary
Added GitHub and LinkedIn social media links to the landing page, alongside the existing Instagram link. This includes new icon components and styling for a social links section.

## Key Changes
- **New icon components**: Created `GithubIcon` and `LinkedInIcon` components in `Nav.js` with consistent styling
- **Refactored icon styling**: Extracted common SVG properties into a reusable `iconBase` object to reduce duplication
- **Social links section**: Added a new `.socials` container on the landing page displaying GitHub and LinkedIn links with icons
- **Styling**: Added CSS for the social links section with hover effects matching the site's design system (accent color transitions)
- **Exports**: Updated exports from `Nav.js` to include the new icon components and URL constants

## Implementation Details
- All social links open in new tabs with `target="_blank"` and `rel="noopener noreferrer"` for security
- Icons use consistent sizing and styling through the shared `iconBase` configuration
- Social section uses flexbox layout with 22px gap and maintains the site's typography (monospace, uppercase, letter-spaced)
- Hover state applies accent color to both text and bottom border for visual feedback

https://claude.ai/code/session_01RHUwDf3ZiuGonEWhw87TRM