### PR TITLE
feat: Broadsheet Red — iconic palette + Gloock / Space Grotesk / IBM Plex Mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ bower_components
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# CRA build output — flattened into repo root by runDeploy.sh; never commit the dir itself
+build/
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/src/Shell.js
+++ b/src/Shell.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-const FONTS_HREF = 'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..600&family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap';
+const FONTS_HREF = 'https://fonts.googleapis.com/css2?family=Gloock&family=Instrument+Serif:ital@0;1&family=Space+Grotesk:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap';
 
 const STORAGE_KEY = 'awong_mode';
 

--- a/src/design-system.css
+++ b/src/design-system.css
@@ -1,41 +1,52 @@
-:root {
-  --paper: #f3efe7;
-  --paper-2: #ebe6dc;
-  --rule: #1a17141a;
-  --ink: #17140f;
-  --ink-2: #3b342b;
-  --ink-3: #6b6356;
-  --ink-4: #a59d8f;
-  --accent: #b0432a;
-  --accent-soft: #b0432a18;
+/* ===========================================================
+   Broadsheet Red — awong.io design system
+   bone paper / ink black / vermilion signal
+   Gloock (Didone) · Space Grotesk · IBM Plex Mono · Instrument Serif
+   =========================================================== */
 
-  --f-display: 'Fraunces', 'Times New Roman', serif;
-  --f-body: 'Inter', system-ui, sans-serif;
-  --f-mono: 'JetBrains Mono', ui-monospace, monospace;
-  --f-italic: 'Instrument Serif', 'Fraunces', serif;
+:root {
+  /* palette */
+  --paper:    #ece6d6;   /* bone */
+  --paper-2:  #e0d9c5;   /* deeper bone for panels / hover zones */
+  --rule:     #0b0b0b24; /* near-black hairline */
+  --rule-bold:#0b0b0b;   /* full rule for statement dividers */
+  --ink:      #0b0b0b;   /* true ink */
+  --ink-2:    #24201b;   /* body ink */
+  --ink-3:    #6a625a;   /* muted */
+  --ink-4:    #a89f93;   /* faint */
+  --accent:   #ee2b14;   /* vermilion */
+  --accent-soft: #ee2b1418;
+
+  /* fonts */
+  --f-display: 'Gloock', 'Didot', 'Bodoni 72', 'Times New Roman', serif;
+  --f-body:    'Space Grotesk', system-ui, -apple-system, sans-serif;
+  --f-mono:    'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --f-italic:  'Instrument Serif', 'Gloock', serif;
 
   --maxw: 860px;
-  --row-h: 1.6;
+  --row-h: 1.55;
 }
 
-[data-accent="ink"]      { --accent: #1d3557; --accent-soft: #1d355718; }
-[data-accent="espresso"] { --accent: #5b3a22; --accent-soft: #5b3a2218; }
-[data-accent="mono"]     { --accent: var(--ink); --accent-soft: #17140f12; }
+/* accent presets (dormant; kept for future switcher) */
+[data-accent="ink"]    { --accent: #0b0b0b; --accent-soft: #0b0b0b14; }
+[data-accent="cobalt"] { --accent: #1f3bff; --accent-soft: #1f3bff18; }
+[data-accent="mono"]   { --accent: var(--ink); --accent-soft: #0b0b0b12; }
 
 [data-mode="dark"] {
-  --paper: #241a12;
-  --paper-2: #2e2319;
-  --rule: #ffffff1f;
-  --ink: #f1e6d0;
-  --ink-2: #d6c8aa;
-  --ink-3: #9f9276;
-  --ink-4: #6e624b;
-  --accent: #e07a5f;
-  --accent-soft: #e07a5f28;
+  --paper:    #0d0f14;   /* graphite */
+  --paper-2:  #161923;
+  --rule:     #ece6d622;
+  --rule-bold:#ece6d6;
+  --ink:      #ece6d6;   /* bone text */
+  --ink-2:    #c9c2b1;
+  --ink-3:    #8a8373;
+  --ink-4:    #55503f;
+  --accent:   #ff5234;   /* hotter red on graphite */
+  --accent-soft: #ff523428;
 }
-[data-mode="dark"][data-accent="ink"]      { --accent: #8fb3e6; --accent-soft: #8fb3e628; }
-[data-mode="dark"][data-accent="espresso"] { --accent: #d6a680; --accent-soft: #d6a68028; }
-[data-mode="dark"][data-accent="mono"]     { --accent: #f1e6d0; --accent-soft: #f1e6d016; }
+[data-mode="dark"][data-accent="ink"]    { --accent: #ece6d6; --accent-soft: #ece6d618; }
+[data-mode="dark"][data-accent="cobalt"] { --accent: #8fb3ff; --accent-soft: #8fb3ff28; }
+[data-mode="dark"][data-accent="mono"]   { --accent: #ece6d6; --accent-soft: #ece6d616; }
 
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; }
@@ -46,40 +57,35 @@ body {
   font-size: 16px;
   line-height: var(--row-h);
   -webkit-font-smoothing: antialiased;
-  font-feature-settings: "ss01", "cv11";
+  text-rendering: optimizeLegibility;
 }
 ::selection { background: var(--accent); color: var(--paper); }
 
 a { color: inherit; }
 
-/* ---- Nav (breadcrumb-style, on every interior page) ---- */
+/* ---- Nav (breadcrumb on interior pages) ---- */
 .nav {
   max-width: var(--maxw);
   margin: 0 auto;
-  padding: 22px 28px 0;
+  padding: 26px 28px 0;
   display: flex;
   gap: 12px;
   align-items: baseline;
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--ink-3);
 }
 .nav .home {
   color: var(--ink);
   text-decoration: none;
-  border-bottom: 1px solid transparent;
-  padding-bottom: 2px;
-  transition: color .15s, border-color .15s;
+  padding-bottom: 3px;
+  border-bottom: 1.5px solid transparent;
+  transition: color .15s ease, border-color .15s ease;
 }
 .nav .home:hover { color: var(--accent); border-bottom-color: var(--accent); }
-.nav .crumb-wrap {
-  margin-left: auto;
-  display: inline-flex;
-  gap: 8px;
-  align-items: baseline;
-}
+.nav .crumb-wrap { margin-left: auto; display: inline-flex; gap: 10px; align-items: baseline; }
 .nav .sep { color: var(--ink-4); }
 .nav .crumb { color: var(--ink); }
 
@@ -90,107 +96,125 @@ a { color: inherit; }
   padding: 48px 28px 120px;
 }
 
-/* ---- Masthead (subpages) ---- */
+/* ---- Masthead (legacy, mostly unused; kept for safety) ---- */
 .masthead {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  border-bottom: 1px solid var(--rule);
+  border-bottom: 1.5px solid var(--rule-bold);
   padding-bottom: 14px;
   margin-bottom: 56px;
 }
-.masthead .section-name {
+.masthead .section-name,
+.masthead .date {
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--ink-3);
 }
 .masthead .section-name b { color: var(--ink); font-weight: 500; }
-.masthead .date {
-  font-family: var(--f-mono);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ink-3);
-}
 
 /* ---- Page headers ---- */
 .dek {
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 20px;
+  margin-bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
 }
+.dek::before {
+  content: '';
+  width: 18px; height: 1.5px;
+  background: var(--accent);
+  display: inline-block;
+}
+
 h1.page-title {
   font-family: var(--f-display);
-  font-weight: 300;
-  font-size: clamp(40px, 5.5vw, 64px);
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-  margin: 0 0 28px;
-  max-width: 16ch;
+  font-weight: 400;
+  font-size: clamp(52px, 8vw, 96px);
+  line-height: 0.96;
+  letter-spacing: -0.025em;
+  margin: 0 0 32px;
+  max-width: 14ch;
 }
-h1.page-title em { font-family: var(--f-italic); font-weight: 400; }
+h1.page-title em {
+  font-family: var(--f-italic);
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
 
 .lede {
-  font-family: var(--f-display);
-  font-size: 19px;
-  line-height: 1.55;
+  font-family: var(--f-body);
+  font-size: 20px;
+  line-height: 1.5;
   color: var(--ink-2);
-  max-width: 62ch;
-  margin: 0 0 72px;
-  font-weight: 300;
+  max-width: 54ch;
+  margin: 0 0 80px;
+  font-weight: 400;
 }
-.lede em { font-family: var(--f-italic); font-style: italic; color: var(--ink); }
+.lede em {
+  font-family: var(--f-italic);
+  font-style: italic;
+  color: var(--accent);
+}
 
-/* ---- Section heads (inside subpages) ---- */
+/* ---- Section heads ---- */
 .sec {
-  padding-top: 56px;
-  border-top: 1px solid var(--rule);
-  margin-top: 56px;
+  padding-top: 64px;
+  border-top: 1.5px solid var(--rule-bold);
+  margin-top: 64px;
 }
 .sec:first-of-type { padding-top: 0; border-top: 0; margin-top: 0; }
 .sec-head {
   display: grid;
   grid-template-columns: 160px 1fr;
   gap: 32px;
-  margin-bottom: 28px;
+  margin-bottom: 32px;
   align-items: baseline;
 }
 .sec-no {
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--ink-3);
 }
 .sec-no b {
   display: block;
-  color: var(--ink);
-  font-weight: 500;
-  margin-bottom: 4px;
+  font-family: var(--f-display);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  margin-bottom: 10px;
 }
 h2.sec-title {
   font-family: var(--f-display);
   font-weight: 400;
-  font-size: 28px;
-  letter-spacing: -0.01em;
+  font-size: 34px;
+  letter-spacing: -0.015em;
   margin: 0;
-  line-height: 1.15;
+  line-height: 1.1;
 }
 
 /* ---- Prose ---- */
 .prose { max-width: 62ch; }
 .prose p { margin: 0 0 1em; font-size: 16.5px; line-height: 1.7; color: var(--ink-2); }
-.prose em { font-family: var(--f-italic); font-style: italic; color: var(--ink); }
+.prose em { font-family: var(--f-italic); font-style: italic; color: var(--accent); }
 .prose a {
   color: var(--ink);
   text-decoration: none;
-  border-bottom: 1px solid var(--accent);
+  border-bottom: 1.5px solid var(--accent);
   padding-bottom: 1px;
+  transition: background .15s ease;
 }
 .prose a:hover { background: var(--accent-soft); }
 
@@ -198,38 +222,39 @@ h2.sec-title {
 footer.page-footer {
   margin-top: 120px;
   padding-top: 24px;
-  border-top: 1px solid var(--rule);
+  border-top: 1.5px solid var(--rule-bold);
   display: flex;
   justify-content: space-between;
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   color: var(--ink-3);
   text-transform: uppercase;
 }
 footer.page-footer a {
   color: var(--ink);
   text-decoration: none;
-  margin-left: 18px;
-  border-bottom: 1px solid transparent;
+  margin-left: 20px;
+  border-bottom: 1.5px solid transparent;
   padding-bottom: 2px;
+  transition: border-color .15s ease, color .15s ease;
 }
-footer.page-footer a:hover { border-color: var(--accent); }
+footer.page-footer a:hover { border-color: var(--accent); color: var(--accent); }
 
-/* ---- Mode toggle (floating light/dark button) ---- */
+/* ---- Mode toggle (floating) ---- */
 .mode-toggle {
-  position: fixed; right: 18px; bottom: 18px; z-index: 60;
-  width: 38px; height: 38px; padding: 0;
+  position: fixed; right: 20px; bottom: 20px; z-index: 60;
+  width: 40px; height: 40px; padding: 0;
   display: inline-flex; align-items: center; justify-content: center;
   background: var(--paper);
-  color: var(--ink-3);
-  border: 1px solid var(--rule);
-  border-radius: 999px;
+  color: var(--ink);
+  border: 1.5px solid var(--ink);
+  border-radius: 2px;
   cursor: pointer;
-  transition: color .15s ease, border-color .15s ease, transform .15s ease;
+  transition: color .15s ease, background .15s ease, transform .15s ease;
 }
-.mode-toggle:hover { color: var(--accent); border-color: var(--accent); }
-.mode-toggle:active { transform: scale(.95); }
+.mode-toggle:hover { background: var(--ink); color: var(--paper); }
+.mode-toggle:active { transform: translateY(1px); }
 
 /* subtle load-in */
 @keyframes fi { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
@@ -239,131 +264,168 @@ footer.page-footer a:hover { border-color: var(--accent); }
 .page > *:nth-child(4) { animation-delay: .15s; }
 
 @media (max-width: 720px) {
-  .sec-head { grid-template-columns: 1fr; gap: 8px; }
+  .sec-head { grid-template-columns: 1fr; gap: 10px; }
+  .sec-no b { font-size: 32px; margin-bottom: 4px; }
 }
 
 /* ===========================================================
-   LANDING PAGE
+   LANDING
    =========================================================== */
 .landing {
   min-height: 100vh;
   display: grid;
   grid-template-rows: 1fr;
-  max-width: 720px;
+  max-width: 760px;
   margin: 0 auto;
-  padding: 32px 28px 40px;
+  padding: 40px 28px 56px;
 }
 .landing .middle {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 80px 0;
+  padding: 72px 0 56px;
 }
 .landing .hello {
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 20px;
+  margin-bottom: 24px;
+  display: inline-flex; align-items: center; gap: 12px;
+}
+.landing .hello::before {
+  content: '';
+  width: 22px; height: 1.5px; background: var(--accent);
+  display: inline-block;
 }
 .landing h1 {
   font-family: var(--f-display);
-  font-weight: 300;
-  font-size: clamp(42px, 6vw, 64px);
-  line-height: 1.08;
-  letter-spacing: -0.02em;
-  margin: 0 0 28px;
-  max-width: 18ch;
+  font-weight: 400;
+  font-size: clamp(64px, 11vw, 132px);
+  line-height: 0.9;
+  letter-spacing: -0.035em;
+  margin: 0 0 36px;
+  max-width: 11ch;
 }
-.landing h1 em { font-family: var(--f-italic); font-weight: 400; }
+.landing h1 em {
+  font-family: var(--f-italic);
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+}
 .landing .intro {
-  font-family: var(--f-display);
-  font-size: 18px;
+  font-family: var(--f-body);
+  font-size: 19px;
   line-height: 1.55;
   color: var(--ink-2);
-  max-width: 52ch;
-  margin: 0 0 56px;
-  font-weight: 300;
+  max-width: 48ch;
+  margin: 0 0 64px;
+  font-weight: 400;
 }
-.landing .intro em { font-family: var(--f-italic); color: var(--ink); font-style: italic; }
+.landing .intro em { font-family: var(--f-italic); font-style: italic; color: var(--accent); }
 
+/* doors */
 .landing nav.primary {
-  border-top: 1px solid var(--rule);
+  border-top: 1.5px solid var(--rule-bold);
 }
-.landing nav.primary a {
+.landing nav.primary a,
+.landing nav.primary .coming {
+  position: relative;
   display: grid;
-  grid-template-columns: 36px 1fr auto 24px;
-  gap: 20px;
-  align-items: baseline;
-  padding: 18px 0;
+  grid-template-columns: 72px 1fr auto 32px;
+  gap: 24px;
+  align-items: center;
+  padding: 22px 0;
   border-bottom: 1px solid var(--rule);
   color: var(--ink);
   text-decoration: none;
-  transition: padding .2s, color .15s;
+  transition: padding .25s cubic-bezier(.22,.61,.36,1);
 }
-.landing nav.primary a:hover {
-  padding-left: 10px;
-  padding-right: 10px;
+.landing nav.primary a::before {
+  content: '';
+  position: absolute;
+  left: -10px; top: 14px; bottom: 14px;
+  width: 3px;
+  background: var(--accent);
+  transform: scaleY(0);
+  transform-origin: center;
+  transition: transform .25s cubic-bezier(.22,.61,.36,1);
 }
-.landing nav.primary a:hover .title { color: var(--accent); }
-.landing nav.primary a:hover .arr { color: var(--accent); transform: translateX(4px); }
+.landing nav.primary a:hover { padding-left: 12px; padding-right: 12px; }
+.landing nav.primary a:hover::before { transform: scaleY(1); }
+.landing nav.primary a:hover .title,
+.landing nav.primary a:hover .arr { color: var(--accent); }
+.landing nav.primary a:hover .arr { transform: translateX(6px); }
+
 .landing nav.primary .n {
-  font-family: var(--f-mono);
-  font-size: 10px;
-  color: var(--ink-4);
-  letter-spacing: 0.1em;
+  font-family: var(--f-display);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--ink-3);
+  align-self: center;
 }
 .landing nav.primary .title {
   font-family: var(--f-display);
-  font-size: 22px;
+  font-size: 28px;
   font-weight: 400;
-  transition: color .15s;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: color .15s ease;
 }
-.landing nav.primary .title em { font-family: var(--f-italic); }
+.landing nav.primary .title em {
+  font-family: var(--f-italic);
+  font-style: italic;
+}
 .landing nav.primary .desc {
   font-family: var(--f-body);
-  font-size: 13px;
+  font-size: 12px;
   color: var(--ink-3);
   text-align: right;
+  letter-spacing: 0.02em;
 }
 .landing nav.primary .arr {
   font-family: var(--f-mono);
-  color: var(--ink-4);
-  transition: transform .2s, color .15s;
+  font-size: 18px;
+  color: var(--ink-3);
+  transition: transform .2s ease, color .15s ease;
+  justify-self: end;
 }
 
+/* "coming" door — WIP */
 .landing nav.primary .coming {
-  display: grid;
-  grid-template-columns: 36px 1fr auto 44px;
-  gap: 20px;
-  align-items: baseline;
-  padding: 18px 0;
-  border-bottom: 1px solid var(--rule);
-  color: var(--ink-3);
+  color: var(--ink-4);
   cursor: default;
-  opacity: .6;
+  opacity: .55;
 }
-.landing nav.primary .coming .title { color: var(--ink-3); }
+.landing nav.primary .coming .n { color: var(--ink-4); }
+.landing nav.primary .coming .title { color: var(--ink-4); }
 .landing nav.primary .coming .arr {
   font-family: var(--f-mono);
   font-size: 9px;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--ink-4);
-  border: 1px solid var(--rule);
-  padding: 2px 6px;
-  border-radius: 2px;
-  text-align: center;
+  color: var(--ink-3);
+  border: 1.5px solid var(--ink-4);
+  padding: 3px 7px;
+  border-radius: 0;
 }
 
 .landing .socials {
-  margin-top: 28px;
+  margin-top: 36px;
+  padding-top: 20px;
+  border-top: 1px solid var(--rule);
   display: flex;
-  gap: 22px;
+  gap: 26px;
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--ink-3);
 }
@@ -373,46 +435,78 @@ footer.page-footer a:hover { border-color: var(--accent); }
   gap: 8px;
   color: var(--ink-3);
   text-decoration: none;
-  padding-bottom: 2px;
-  border-bottom: 1px solid transparent;
-  transition: color .15s, border-color .15s;
+  padding-bottom: 3px;
+  border-bottom: 1.5px solid transparent;
+  transition: color .15s ease, border-color .15s ease;
 }
 .landing .socials a:hover { color: var(--accent); border-bottom-color: var(--accent); }
 
 @media (max-width: 520px) {
   .landing nav.primary a,
-  .landing nav.primary .coming { grid-template-columns: 28px 1fr 44px; gap: 14px; }
+  .landing nav.primary .coming { grid-template-columns: 44px 1fr 32px; gap: 16px; }
   .landing nav.primary .desc { display: none; }
+  .landing nav.primary .n { font-size: 28px; }
+  .landing nav.primary .title { font-size: 22px; }
 }
 
 /* ===========================================================
-   SECTION-SPECIFIC BITS
+   SECTION-SPECIFIC
    =========================================================== */
 
-/* Tinkering — project index */
+/* Tinkering — project rows */
 .proj {
   display: grid;
   grid-template-columns: 120px 1fr auto;
   gap: 28px;
-  padding: 18px 0;
+  padding: 20px 0;
   border-top: 1px solid var(--rule);
   align-items: baseline;
   cursor: pointer;
-  transition: padding .2s, background .2s;
+  transition: padding .2s ease, background .2s ease;
 }
 .proj:last-child { border-bottom: 1px solid var(--rule); }
-.proj:hover, .proj[data-open] { background: var(--paper-2); padding-left: 12px; padding-right: 12px; }
-.proj .yr { font-family: var(--f-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.08em; }
-.proj .title { font-family: var(--f-display); font-size: 20px; font-weight: 400; }
-.proj .title em { font-family: var(--f-italic); }
-.proj .title small { font-family: var(--f-body); font-size: 13px; color: var(--ink-3); display: block; margin-top: 2px; font-weight: 400; }
-.proj .tag { font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); }
-.proj-detail {
-  display: none; grid-column: 2 / 4;
-  padding: 10px 0 16px; color: var(--ink-2);
-  font-size: 15px; line-height: 1.65; max-width: 62ch;
+.proj:hover, .proj[data-open] { background: var(--paper-2); padding-left: 14px; padding-right: 14px; }
+.proj .yr {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  letter-spacing: 0.14em;
 }
-.proj-detail em { font-family: var(--f-italic); color: var(--ink); font-style: italic; }
+.proj .title {
+  font-family: var(--f-display);
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+.proj .title em { font-family: var(--f-italic); font-style: italic; color: var(--accent); }
+.proj .title small {
+  font-family: var(--f-body);
+  font-size: 13px;
+  color: var(--ink-3);
+  display: block;
+  margin-top: 4px;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+.proj .tag {
+  font-family: var(--f-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.proj[data-open] .tag { color: var(--accent); }
+.proj-detail {
+  display: none;
+  grid-column: 2 / 4;
+  padding: 12px 0 18px;
+  color: var(--ink-2);
+  font-size: 15px;
+  line-height: 1.7;
+  max-width: 62ch;
+}
+.proj-detail em { font-family: var(--f-italic); font-style: italic; color: var(--accent); }
 .proj[data-open] .proj-detail { display: block; }
 
 /* Photography grid */
@@ -429,9 +523,9 @@ footer.page-footer a:hover { border-color: var(--accent); }
 }
 .ph svg { width: 100%; height: 100%; display: block; }
 .ph .cap {
-  position: absolute; left: 10px; bottom: 8px; right: 10px;
-  font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.08em;
-  color: #f3efe7; text-transform: uppercase;
+  position: absolute; left: 12px; bottom: 10px; right: 12px;
+  font-family: var(--f-mono); font-size: 10px; letter-spacing: 0.14em;
+  color: #ece6d6; text-transform: uppercase;
   opacity: 0; transform: translateY(6px); transition: all .35s ease;
   text-shadow: 0 1px 10px #000a;
   display: flex; justify-content: space-between;
@@ -454,18 +548,24 @@ footer.page-footer a:hover { border-color: var(--accent); }
   display: grid;
   grid-template-columns: 110px 1fr 150px 80px;
   gap: 24px;
-  padding: 14px 0;
+  padding: 16px 0;
   border-top: 1px solid var(--rule);
   font-size: 14px;
   align-items: baseline;
 }
 .brew:last-child { border-bottom: 1px solid var(--rule); }
-.brew .d { font-family: var(--f-mono); color: var(--ink-3); font-size: 11px; letter-spacing: 0.08em; }
-.brew .bean { font-family: var(--f-display); font-size: 17px; }
-.brew .bean b { font-weight: 500; }
-.brew .bean small { font-family: var(--f-body); color: var(--ink-3); display: block; font-size: 12px; margin-top: 2px; }
-.brew .method { font-family: var(--f-mono); font-size: 11px; color: var(--ink-2); letter-spacing: 0.04em; }
-.brew .score { font-family: var(--f-display); font-size: 22px; text-align: right; color: var(--ink); }
+.brew .d { font-family: var(--f-mono); color: var(--ink-3); font-size: 11px; letter-spacing: 0.14em; }
+.brew .bean { font-family: var(--f-display); font-size: 19px; letter-spacing: -0.005em; }
+.brew .bean b { font-weight: 400; }
+.brew .bean small {
+  font-family: var(--f-body); color: var(--ink-3); display: block;
+  font-size: 12px; margin-top: 4px; letter-spacing: 0;
+}
+.brew .method {
+  font-family: var(--f-mono); font-size: 11px; color: var(--ink-2); letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.brew .score { font-family: var(--f-display); font-size: 26px; text-align: right; color: var(--accent); }
 .brew .score small { color: var(--ink-3); font-size: 12px; font-family: var(--f-body); }
 
 @media (max-width: 640px) {
@@ -480,25 +580,25 @@ footer.page-footer a:hover { border-color: var(--accent); }
 /* Now list */
 .now-list { list-style: none; padding: 0; margin: 0; max-width: 62ch; }
 .now-list li {
-  padding: 14px 0;
+  padding: 16px 0;
   border-top: 1px solid var(--rule);
   display: grid;
   grid-template-columns: 120px 1fr;
   gap: 24px;
   font-size: 16px;
   color: var(--ink-2);
-  line-height: 1.55;
+  line-height: 1.6;
 }
 .now-list li:last-child { border-bottom: 1px solid var(--rule); }
 .now-list li b {
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--ink-3);
   font-weight: 500;
 }
-.now-list li em { font-family: var(--f-italic); font-style: italic; color: var(--ink); }
+.now-list li em { font-family: var(--f-italic); font-style: italic; color: var(--accent); }
 
 /* Contact links */
 .contact-list { list-style: none; padding: 0; margin: 0 0 32px; max-width: 62ch; }
@@ -506,7 +606,7 @@ footer.page-footer a:hover { border-color: var(--accent); }
   display: grid;
   grid-template-columns: 120px 1fr auto;
   gap: 24px;
-  padding: 16px 0;
+  padding: 18px 0;
   border-top: 1px solid var(--rule);
   align-items: baseline;
 }
@@ -514,23 +614,24 @@ footer.page-footer a:hover { border-color: var(--accent); }
 .contact-list li b {
   font-family: var(--f-mono);
   font-size: 11px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--ink-3);
   font-weight: 500;
 }
 .contact-list li a {
   font-family: var(--f-display);
-  font-size: 18px;
+  font-size: 20px;
+  letter-spacing: -0.005em;
   color: var(--ink);
   text-decoration: none;
-  border-bottom: 1px solid var(--accent);
-  padding-bottom: 1px;
+  border-bottom: 1.5px solid var(--accent);
+  padding-bottom: 2px;
 }
 .contact-list li a:hover { background: var(--accent-soft); }
 .contact-list li .handle {
   font-family: var(--f-mono);
   font-size: 11px;
   color: var(--ink-3);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
 }


### PR DESCRIPTION
Pushes the site away from a warm-paper editorial default toward a high-contrast
broadsheet identity: bone paper, true ink, vermilion signal. Gloock (single-weight
Didone) carries display type; Space Grotesk replaces Inter for body; IBM Plex Mono
replaces JetBrains for labels; Instrument Serif italic stays as the signature
italic (now rendered in accent red for the name treatment, section dividers, and
sparing emphasis).

Landing doors get oversized Gloock numerals and a left accent-stripe indicator on
hover. Section headers carry display numerals. Rules at statement boundaries are
1.5px; hairlines stay light. Dek eyebrow gets a small red tick. Mode toggle is
now square with an invert hover. Dark mode shifts to graphite paper + hot red.